### PR TITLE
Fix is_idle method to check _idle attribute of threads

### DIFF
--- a/pool_workers/__init__.py
+++ b/pool_workers/__init__.py
@@ -124,7 +124,7 @@ class Pool:
         return any((t.is_alive() for t in self.threads))
 
     def is_idle(self):
-        return False not in (t.idle() for t in self.threads)
+        return False not in (t._idle.is_set() for t in self.threads)
 
     def is_done(self):
         return self.queue.empty()


### PR DESCRIPTION
The idle() function in Thread class is not available, nor in Worker class, which breaks the implementation of idle() function in Pool class.